### PR TITLE
Fix bug with games page title in fullscreen

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -111,6 +111,7 @@ body {
     border: none;
     border-radius: 15px;
     box-shadow: 0 9px #999;
+    margin-top: 25px; /* Adjust this value to get the desired amount of space */
 }
 
 .button:hover {background-color: #D30000}

--- a/assets/css/text_styles.css
+++ b/assets/css/text_styles.css
@@ -16,7 +16,7 @@
 }
 
 
-.title_text{
+.title_text {
     position: absolute;
     top: 10%;
     left: 50%;
@@ -27,8 +27,15 @@
     font-family: 'League Spartan', sans-serif;
     transform: translateX(-50%);
     line-height: 120%;
+    
+    /* Flex for stacking */
+    display: flex;
+    flex-direction: column;
+    align-items: center; /* This will center-align your iframe and button horizontally */
+    justify-content: center; /* Optional: This will center-align items vertically */
 
 }
+
 .title_text_main{
     position: relative;
     top: 10%;


### PR DESCRIPTION
This should solve #7 . I changed the title_text item to be a flexbox instead of a block, this allowed my to set the flex-direction to column and align-items center. Doing so will make the items always appear in a column, instead of next to each other. 

I also needed to add a little css change to the Fullscreen button since the parent flexbox will pull items together, I accomplished this with a margin-top property. 