### PR TITLE
Fixed a warning + Added comments

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -1,0 +1,12 @@
+# Contributors
+
+- [Maddox Schmidlkofer](https://github.com/maddox05)
+- [Light Andy](https://github.com/LightAndy1)
+- [Aaryan](https://github.com/An-Array)
+- [Sumit Verma](https://github.com/SumitVerma-coder)
+- [Carbon Neuron](https://github.com/CarbonNeuron)
+- [Shubhangam Saxena](https://github.com/Shubhangam333)
+- [Shovit](https://github.com/Virtual4087)
+- [DanielZhang111](https://github.com/DanielZhang111)
+- [Sidhartha Mohanty](https://github.com/sidhartha2002)
+- [CHAYANDEV BERA](https://github.com/Chayandev)

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -154,6 +154,11 @@ body {
   touch-action: manipulation;
 }
 
+.button-55.github {
+  min-width: 320px;
+  font-size: 45px;
+}
+
 .button-55:hover {
   box-shadow: rgba(0, 0, 0, 0.3) 2px 8px 8px -5px;
   transform: translate3d(0, 2px, 0);

--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <!--^ Google Scripts -->
     <script
       async
       src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-1533872335883359"
@@ -19,8 +20,10 @@
       gtag("config", "G-63K8BHHS38");
     </script>
 
+    <!--? Title -->
     <title>DuckMath</title>
 
+    <!--? Meta Tags -->
     <meta property="og:title" content="DuckMath" />
     <meta
       property="og:description"
@@ -39,15 +42,17 @@
     />
     <meta name="language" content="English" />
 
+    <!--* Stylesheets -->
     <link rel=”canonical” href=”https://duckmath.org/”>
     <link rel="stylesheet" href="/assets/css/text_styles.css" />
     <link rel="stylesheet" href="/assets/css/topnav.css" />
     <link rel="stylesheet" href="/assets/css/main.css" />
-    <!--<link rel="stylesheet" href="/assets/css/gabes.css" />-->
+    <!--// <link rel="stylesheet" href="/assets/css/gabes.css" /> -->
     <link rel="stylesheet" href="/assets/css/tooltips.css" />
     <link rel="icon" type="image/x-icon" href="/assets/img/duck.png" />
     <link rel="mask-icon" type="" href="/assets/img/duck.png" color="#111" />
 
+    <!--^ Basic Scripts -->
     <script src="/assets/js/main.js" type="text/javascript" defer></script>
     <script src="/assets/js/index.js" type="text/javascript" defer></script>
     <script src="/firebase/main_firebase.js" type="module" defer></script>
@@ -66,7 +71,7 @@
 
         <br>
 
-        <button class="tooltip button-55" style="min-width:320px; font-size: 45px;"
+        <button class="tooltip button-55 github"
                 onclick="window.location='https://github.com/duckmath/duckmath.github.io'">Github
           <div class="tooltiptext">
                     <span class="tag">
@@ -77,9 +82,8 @@
           </div>
         </button>
         <!-- HALLOWEEN
-        <br>
-        <img  src="/assets/img/pumpkingif-halloween.gif" height="200" width="200" style="margin-top: 60px" loading="lazy" alt="pumpkin-gif">
-            -->
+        <br />
+        <img  src="/assets/img/pumpkingif-halloween.gif" height="200" width="200" style="margin-top: 60px" loading="lazy" alt="pumpkin-gif"> -->
       </div>
         </button>
       </div>
@@ -130,6 +134,6 @@
       </div>
     </main>
 
-    <!--<div class = "bottom_text">Copyright © 2022-2023 Duck Math - All Rights Reserved.</div>-->
+    <!--// <div class = "bottom_text">Copyright © 2022-2023 Duck Math - All Rights Reserved.</div> -->
   </body>
 </html>


### PR DESCRIPTION
## ⚠️ Warning Related
Removed the following code from HTML and added it in CSS to fix a VS Code warning:

1. **HTML** _(Old & Removed)_
```html
style="min-width:320px; font-size: 45px;"
```

2. **CSS** _(New & Added)_

```css
.button-55.github {
  min-width: 320px;
  font-size: 45px;
}
```

## 💬 Comments
Added some comment to the head of the HTML code to be more readable. Some examples: `Google Scripts`, `Title`, `Stylesheets` etc.
> Note: I recommend using the [Colorful Comments](https://marketplace.visualstudio.com/items?itemName=ParthR2031.colorful-comments) extension for VS Code to see the comments coloured.