### PR TITLE
A temporary fix for the mobile topnav

### DIFF
--- a/assets/css/topnav.css
+++ b/assets/css/topnav.css
@@ -176,6 +176,11 @@ ul a:hover {
   #hamburger-icon {
     display: block;
   }
+  .dropdown-content {
+    display: block !important;
+    min-width: 60px;
+    transform: translateX(49px);
+  }
 }
 
 .dropdown-content a:hover {


### PR DESCRIPTION
## Pull Request Description

- Implemented a temporary fix for the mobile version of the `.dropdown-content` (MORE button) in the hamburger menu.
- Adjusted it to always appear, ensuring accessibility to those pages regardless of other conditions.

> Related to issue #28.