### PR TITLE
Add margin-right when scrollbar's not visible

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -8,8 +8,8 @@ body {
   color: #fff;
   overflow-x: hidden;
   letter-spacing: 0.2px;
-  -webkit-transition: all 200ms linear;
-  transition: all 200ms linear;
+  /* -webkit-transition: all 200ms linear; */
+  /* transition: all 200ms linear; */
   text-rendering: optimizeLegibility !important;
   -webkit-font-smoothing: antialiased !important;
   scroll-behavior: smooth;
@@ -400,4 +400,12 @@ input[type="search"]::-webkit-search-cancel-button {
   *::-webkit-scrollbar {
     display: none;
   }
+}
+
+.no-scroll {
+  margin-right: 26px;
+}
+
+.topnav.no-scroll {
+  width: calc(98% - 26px);
 }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -48,6 +48,21 @@ document.addEventListener("DOMContentLoaded", function () {
   }
 });
 
+document.addEventListener("click", function (event) {
+  if (event.target.classList.contains("sorter")) {
+    const topnav = document.getElementById("topnav");
+    if (document.body.scrollHeight <= window.innerHeight) {
+      document.body.classList.add("no-scroll");
+      topnav.classList.add("no-scroll");
+      console.log("no scroll");
+    } else {
+      document.body.classList.remove("no-scroll");
+      topnav.classList.remove("no-scroll");
+      console.log("scroll");
+    }
+  }
+});
+
 let prevScrollPos = window.pageYOffset;
 let ticking = false;
 
@@ -88,8 +103,6 @@ function openFullscreen() {
 function ruffleFullscreen() {
   alert("To Fullscreen, Right Click the Application and hit Enter Fullscreen");
 }
-
-
 
 function searchbar1() {
   const searchvalue = document.getElementById("query");

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -54,11 +54,9 @@ document.addEventListener("click", function (event) {
     if (document.body.scrollHeight <= window.innerHeight) {
       document.body.classList.add("no-scroll");
       topnav.classList.add("no-scroll");
-      console.log("no scroll");
     } else {
       document.body.classList.remove("no-scroll");
       topnav.classList.remove("no-scroll");
-      console.log("scroll");
     }
   }
 });

--- a/index.html
+++ b/index.html
@@ -65,19 +65,19 @@
     </div>
     <br />
 
-    <button id = "All" class="button2" onclick="showall();sorterbuttons(this);">All</button>
-    <button id = "Multiplayer" class="button1" onclick="sorter('Multiplayer');sorterbuttons(this);">Multiplayer</button>
-    <button id = "Flash" class="button1" onclick="sorter('Flash');sorterbuttons(this);">Flash</button>
-    <button id = "Emulator" class="button1" onclick="sorter('Emulator');sorterbuttons(this);">Emulator</button>
-    <button id = "Platformer" class="button1" onclick="sorter('Platformer');sorterbuttons(this);">Platformer</button>
-    <button id = "Puzzle" class="button1" onclick="sorter('Puzzle');sorterbuttons(this);">Puzzle</button>
-    <button id = "Sports" class="button1" onclick="sorter('Sports');sorterbuttons(this);">Sports</button>
-    <button id = "Driving" class="button1" onclick="sorter('Driving');sorterbuttons(this);">Driving</button>
-    <button id = "Fighting" class="button1" onclick="sorter('Fighting');sorterbuttons(this);">Fighting</button>
-    <button id = "Horror" class="button1" onclick="sorter('Horror');sorterbuttons(this);">Horror</button>
-    <button id = "2D" class="button1" onclick="sorter('2D');sorterbuttons(this);">2D</button>
-    <button id = "Other" class="button1" onclick="sorter('Other');sorterbuttons(this);">Other</button>
-    <button id = "New" class="button3" onclick="sorter('New');sorterbuttons(this);">New</button> <!-- wierd click effect -->
+    <button id = "All" class="button2 sorter" onclick="showall();sorterbuttons(this);">All</button>
+    <button id = "Multiplayer" class="button1 sorter" onclick="sorter('Multiplayer');sorterbuttons(this);">Multiplayer</button>
+    <button id = "Flash" class="button1 sorter" onclick="sorter('Flash');sorterbuttons(this);">Flash</button>
+    <button id = "Emulator" class="button1 sorter" onclick="sorter('Emulator');sorterbuttons(this);">Emulator</button>
+    <button id = "Platformer" class="button1 sorter" onclick="sorter('Platformer');sorterbuttons(this);">Platformer</button>
+    <button id = "Puzzle" class="button1 sorter" onclick="sorter('Puzzle');sorterbuttons(this);">Puzzle</button>
+    <button id = "Sports" class="button1 sorter" onclick="sorter('Sports');sorterbuttons(this);">Sports</button>
+    <button id = "Driving" class="button1 sorter" onclick="sorter('Driving');sorterbuttons(this);">Driving</button>
+    <button id = "Fighting" class="button1 sorter" onclick="sorter('Fighting');sorterbuttons(this);">Fighting</button>
+    <button id = "Horror" class="button1 sorter" onclick="sorter('Horror');sorterbuttons(this);">Horror</button>
+    <button id = "2D" class="button1 sorter" onclick="sorter('2D');sorterbuttons(this);">2D</button>
+    <button id = "Other" class="button1 sorter" onclick="sorter('Other');sorterbuttons(this);">Other</button>
+    <button id = "New" class="button3 sorter" onclick="sorter('New');sorterbuttons(this);">New</button> <!-- wierd click effect -->
 
 
 


### PR DESCRIPTION
When the page's scrollbar is not visible, it adds a margin-right of 26px so that elements don't move when pressing on the sort buttons. When it reappears, it removes that margin. This addition is only for the main page and it only works with the sorter buttons.